### PR TITLE
fix: prevent altering task creation timestamp

### DIFF
--- a/backend/TaskManagementApi/Controllers/TaskController.cs
+++ b/backend/TaskManagementApi/Controllers/TaskController.cs
@@ -98,20 +98,19 @@ public class TaskController : ControllerBase{
     [Authorize]
     [HttpPut("{id}")]
     public async Task<IActionResult> UpdateTask(int id, [FromBody] TaskDTO updatedTask){
-        if(_context.TaskItems.Find(id) == null){
+        var task = await _context.TaskItems.FindAsync(id);
+        if(task == null){
             return NotFound("Task not found.");
         }
-        var task = _context.TaskItems.Find(id);
 
         task.Title = updatedTask.Title;
         task.Description = updatedTask.Description;
         task.DueDate = updatedTask.DueDate;
-        task.CreatedAt = updatedTask.CreatedAt;
         task.Status = updatedTask.Status;
         task.Priority = updatedTask.Priority;
         task.UserId = updatedTask.UserId;
         task.CategoryId = updatedTask.CategoryId;
-        
+
         _context.TaskItems.Update(task);
         await _context.SaveChangesAsync();
         return NoContent();


### PR DESCRIPTION
## Summary
- avoid overwriting task creation timestamps when updating a task
- use asynchronous lookup when retrieving tasks for update

## Testing
- `dotnet build task-manager.sln` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: repository InRelease not signed)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6891e91f37988322a0c88cc555cd5031